### PR TITLE
Add extra support for invocation creation and extensions (OSK-2)

### DIFF
--- a/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
@@ -29,6 +29,7 @@ namespace OSK.Expression.Invoker.UnitTests
             Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
             Assert.Equal(typeof(int), invoker.ReturnType);
             Assert.Equal(InvocationType.Field, invoker.InvocationType);
+            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
         }
 
         [Fact]
@@ -51,6 +52,7 @@ namespace OSK.Expression.Invoker.UnitTests
             Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
             Assert.Equal(typeof(int), invoker.ReturnType);
             Assert.Equal(InvocationType.Field, invoker.InvocationType);
+            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
         }
 
         #endregion
@@ -76,6 +78,7 @@ namespace OSK.Expression.Invoker.UnitTests
             Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
             Assert.Equal(typeof(int), invoker.ReturnType);
             Assert.Equal(InvocationType.Property, invoker.InvocationType);
+            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
         }
 
         #endregion
@@ -101,6 +104,7 @@ namespace OSK.Expression.Invoker.UnitTests
             Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
             Assert.Equal(typeof(void), invoker.ReturnType);
             Assert.Equal(InvocationType.Method, invoker.InvocationType);
+            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
         }
 
         [Fact]
@@ -122,6 +126,7 @@ namespace OSK.Expression.Invoker.UnitTests
             Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
             Assert.Equal(typeof(int), invoker.ReturnType);
             Assert.Equal(InvocationType.Method, invoker.InvocationType);
+            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
         }
 
         #endregion

--- a/src/OSK.Expressions.Invoker/Internal/FastInvoker.cs
+++ b/src/OSK.Expressions.Invoker/Internal/FastInvoker.cs
@@ -4,11 +4,14 @@ using System;
 
 namespace OSK.Expressions.Invoker.Internal;
 
-internal sealed class FastInvoker(Func<object, object[], object> func, MemberKey memberKey, InvocationType invocationType) : IInvoker
+internal sealed class FastInvoker(Func<object, object[], object> func, MemberKey memberKey, InvocationType invocationType,
+    Type invokeTargetType) : IInvoker
 {
     #region IInvoker
 
     public InvocationType InvocationType => invocationType;
+
+    public Type InvokeTargetType => invokeTargetType;
 
     public Type ReturnType => memberKey.ReturnType;
 

--- a/src/OSK.Expressions.Invoker/InvokerExtensions.cs
+++ b/src/OSK.Expressions.Invoker/InvokerExtensions.cs
@@ -1,0 +1,38 @@
+﻿using OSK.Expressions.Invoker.Ports;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OSK.Expressions.Invoker
+{
+    public static class InvokerExtensions
+    {
+        extension(IInvoker invoker)
+        {
+            /// <summary>
+            /// Effeciently run the invoker on the targeted object without parameters
+            /// </summary>
+            /// <param name="invokeTarget">The object to invoke</param>
+            /// <returns></returns>
+            public object FastInvoke(object invokeTarget)
+                => invoker.FastInvoke(invokeTarget, []);
+
+            /// <summary>
+            /// Effeciently run the invoker on the targeted object without parameters
+            /// </summary>
+            /// <param name="invokeTarget">The object to invoke</param>
+            /// <returns>A typed result</returns>
+            public T FastInvoke<T>(object invokeTarget)
+                => (T)invoker.FastInvoke(invokeTarget, []);
+
+            /// <summary>
+            /// Effeciently run the invoker on the targeted object
+            /// </summary>
+            /// <param name="invokeTarget">The object to invoke</param>
+            /// <param name="parameters">The parameters to pass to the invocation</param>
+            /// <returns></returns>
+            public T FastInvoke<T>(object invokeTarget, object[] parameters)
+                => (T)invoker.FastInvoke(invokeTarget, parameters);
+        }
+    }
+}

--- a/src/OSK.Expressions.Invoker/InvokerFactory.cs
+++ b/src/OSK.Expressions.Invoker/InvokerFactory.cs
@@ -21,7 +21,7 @@ namespace OSK.Expressions.Invoker
         #region Api
 
         /// <summary>
-        /// Create a <see cref="IInvoker"/> using a strongly typed reference.
+        /// Create a <see cref="IInvoker"/> using a strongly typed reference and an expression to retrieve the member data.
         /// </summary>
         /// <typeparam name="T">The object target type</typeparam>
         /// <param name="memberSelector">An expression to retrieve the member</param>
@@ -30,13 +30,22 @@ namespace OSK.Expressions.Invoker
             => CreateInvoker(typeof(T), GetMemberInfo(memberSelector));
 
         /// <summary>
-        /// Create a <see cref="IInvoker"/> using a strongly typed reference.
+        /// Create a <see cref="IInvoker"/> using a strongly typed reference and an expression to retrieve the member data.
         /// </summary>
         /// <typeparam name="T">The object target type</typeparam>
         /// <param name="memberSelector">An expression to retrieve the member</param>
         /// <returns><see cref="IInvoker"/></returns>
         public static IInvoker CreateInvoker<T>(Expression<Func<T, object>> memberSelector)
             => CreateInvoker(typeof(T), GetMemberInfo(memberSelector));
+
+        /// <summary>
+        /// Create a <see cref="IInvoker"/> using a strongly typed reference and a member info
+        /// </summary>
+        /// <typeparam name="T">The object target type</typeparam>
+        /// <param name="memberInfo">The member info to create an invoker for</param>
+        /// <returns><see cref="IInvoker"/></returns>
+        public static IInvoker CreateInvoker<T>(MemberInfo memberInfo)
+            => CreateInvoker(typeof(T), memberInfo);
 
         /// <summary>
         /// Creates a <see cref="IInvoker"/> using a <see cref="MemberInfo"/>, provided a target object type
@@ -63,7 +72,7 @@ namespace OSK.Expressions.Invoker
                 return MemberToWrapperMap.GetOrAdd(methodKey, memberKey =>
                 {
                     var compiledExpression = CreateMethodCompiledExpression(memberKey.InvocationTargetType, methodInfo, false);
-                    return new FastInvoker(compiledExpression, memberKey, InvocationType.Method);
+                    return new FastInvoker(compiledExpression, memberKey, InvocationType.Method, invocationTargetType);
                 });
             }
 
@@ -72,7 +81,8 @@ namespace OSK.Expressions.Invoker
             {
                 var (compiledExpression, memberType) = CreateMemberCompiledExpression(invocationTargetType, memberInfo);
                 return new FastInvoker(compiledExpression, k.SetParameterTypes(memberType), 
-                    memberInfo is PropertyInfo _ ? InvocationType.Property : InvocationType.Field);
+                    memberInfo is PropertyInfo _ ? InvocationType.Property : InvocationType.Field,
+                    invocationTargetType);
             });
         }
 

--- a/src/OSK.Expressions.Invoker/OSK.Expressions.Invoker.csproj
+++ b/src/OSK.Expressions.Invoker/OSK.Expressions.Invoker.csproj
@@ -23,4 +23,8 @@
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="OSK.Hexagonal.MetaData" Version="1.0.0" />
+	</ItemGroup>
+
 </Project>

--- a/src/OSK.Expressions.Invoker/Ports/IInvoker.cs
+++ b/src/OSK.Expressions.Invoker/Ports/IInvoker.cs
@@ -1,16 +1,38 @@
 ﻿using OSK.Expressions.Invoker.Models;
+using OSK.Hexagonal.MetaData;
 using System;
 
 namespace OSK.Expressions.Invoker.Ports
 {
+    [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
     public interface IInvoker
     {
+        /// <summary>
+        /// The type of invocation this invoker is configured to support
+        /// </summary>
         InvocationType InvocationType { get; }
 
+        /// <summary>
+        /// The type of object that should be passed to the invoker
+        /// </summary>
+        Type InvokeTargetType { get; }
+
+        /// <summary>
+        /// The expected parameter types to be provided to the invoker to function
+        /// </summary>
         Type[] ParameterTypes { get; }
 
+        /// <summary>
+        /// The return type of the member info that was used to create this invoker
+        /// </summary>
         Type ReturnType { get; }
 
+        /// <summary>
+        /// Effeciently run the invoker on the targeted object
+        /// </summary>
+        /// <param name="invokeTarget">The object to invoke</param>
+        /// <param name="parameters">The parameters to pass to the invocation</param>
+        /// <returns></returns>
         object FastInvoke(object invokeTarget, object[] parameters);
     }
 }


### PR DESCRIPTION
Motivation
----
There are some extensions that would be helpful for usage with the invoker as well as the factory that creates them

Modifications
----
* Added a method endpoint to create an invoker with a strongly typed reference and a member info directly
* Added extensions for IInvoker
* Added hexagonal meta data

Result
----
Some additional methods are available that should be helpful

Fixes #2