### PR TITLE
Allow Getters and update docs (OSK-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # OSK.Expressions.Invoker
 Efficiently invoke custom compiled expressions for functions with varying parameter and return types. This library provides helper utilities to create the invokers for instance objects.
 
+# Usage
+The central focal point of the library is the `Invok6erFactory`. This static class provides a variety of APIs to generate an invoker that can efficiently, and quickly make method, property, and field calls on objects of any type.
+For Property/Fields, it is assumed that the getter is intended to be used if the invoker is called without a parameter provided and the setter will be used if a parameter is provided.
 
 # Contributions and Issues
 Any and all contributions are appreciated! Please be sure to follow the branch naming convention OSK-{issue number}-{deliminated}-{branch}-{name} as current workflows rely on it for automatic issue closure. Please submit issues for discussion and tracking using the github issue tracker.

--- a/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
@@ -4,131 +4,196 @@ using OSK.Expressions.Invoker.Models;
 using System.Diagnostics;
 using System.Reflection;
 
-namespace OSK.Expression.Invoker.UnitTests
+namespace OSK.Expression.Invoker.UnitTests;
+
+public class InvokerFactoryTests
 {
-    public class InvokerFactoryTests
+    #region Fields
+
+    [Fact]
+    public void InvokerFactory_Class_Public_FieldSetter()
     {
-        #region Fields
-
-        [Fact]
-        public void InvokerFactory_Class_Public_FieldSetter()
+        // Arrange
+        var testClass = new TestClass()
         {
-            // Arrange
-            var testClass = new TestClass()
-            {
-                PropertyB = 1
-            };
+            PropertyB = 1
+        };
 
-            // Act
-            var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyB);
-            invoker.FastInvoke(testClass, [2]);
+        // Act
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyB);
+        invoker.FastInvoke(testClass, [2]);
 
-            // Assert
-            Assert.Equal(2, testClass.PropertyB); 
-            Assert.Single(invoker.ParameterTypes);
-            Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
-            Assert.Equal(typeof(int), invoker.ReturnType);
-            Assert.Equal(InvocationType.Field, invoker.InvocationType);
-            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
-        }
-
-        [Fact]
-        public void InvokerFactory_Class_Private_FieldSetter()
-        {
-            // Arrange
-            var testClass = new TestClass();
-            testClass.SetC(5);
-            Assert.Equal(5, testClass.PropertyC);
-
-            var privateMember = typeof(TestClass).GetField("_propertyC", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            // Act
-            var invoker = InvokerFactory.CreateInvoker(typeof(TestClass), privateMember!);
-            invoker.FastInvoke(testClass, [2]);
-
-            // Assert
-            Assert.Equal(2, testClass.PropertyC);
-            Assert.Single(invoker.ParameterTypes);
-            Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
-            Assert.Equal(typeof(int), invoker.ReturnType);
-            Assert.Equal(InvocationType.Field, invoker.InvocationType);
-            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
-        }
-
-        #endregion
-
-        #region Properties
-
-        [Fact]
-        public void InvokerFactory_Class_Public_PropertySetter()
-        {
-            // Arrange
-            var testClass = new TestClass()
-            {
-                PropertyA = 1
-            };
-
-            // Act
-            var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyA);
-            invoker.FastInvoke(testClass, [2]);
-
-            // Assert
-            Assert.Equal(2, testClass.PropertyA);
-            Assert.Single(invoker.ParameterTypes);
-            Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
-            Assert.Equal(typeof(int), invoker.ReturnType);
-            Assert.Equal(InvocationType.Property, invoker.InvocationType);
-            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
-        }
-
-        #endregion
-
-        #region Methods
-
-        [Fact]
-        public void InvokerFactory_Class_Method_Void()
-        {
-            // Arrange
-            var testClass = new TestClass()
-            {
-                PropertyA = 12
-            };
-            var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.MethodA(0));
-
-            // Act
-            invoker.FastInvoke(testClass, [2]);
-
-            // Assert
-            Assert.Equal(2, testClass.PropertyA);
-            Assert.Single(invoker.ParameterTypes); 
-            Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
-            Assert.Equal(typeof(void), invoker.ReturnType);
-            Assert.Equal(InvocationType.Method, invoker.InvocationType);
-            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
-        }
-
-        [Fact]
-        public void InvokerFactory_Class_Method_ReturnsOutput()
-        {
-            // Arrange
-            var testClass = new TestClass()
-            {
-                PropertyA = 12
-            };
-
-            // Act
-            var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.MethodB(0));
-            var result = (int)invoker.FastInvoke(testClass, [2]);
-
-            // Assert
-            Assert.Equal(2, result);
-            Assert.Single(invoker.ParameterTypes);
-            Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
-            Assert.Equal(typeof(int), invoker.ReturnType);
-            Assert.Equal(InvocationType.Method, invoker.InvocationType);
-            Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
-        }
-
-        #endregion
+        // Assert
+        Assert.Equal(2, testClass.PropertyB); 
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Field, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
     }
+
+    [Fact]
+    public void InvokerFactory_Class_Public_FieldGetter()
+    {
+        // Arrange
+        var testClass = new TestClass()
+        {
+            PropertyB = 1
+        };
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyB);
+        var b = invoker.FastInvoke<int>(testClass);
+
+        // Assert
+        Assert.Equal(testClass.PropertyB, b);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Field, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    [Fact]
+    public void InvokerFactory_Class_Private_FieldSetter()
+    {
+        // Arrange
+        var testClass = new TestClass();
+        testClass.SetC(5);
+        Assert.Equal(5, testClass.PropertyC);
+
+        var privateMember = typeof(TestClass).GetField("_propertyC", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker(typeof(TestClass), privateMember!);
+        invoker.FastInvoke(testClass, [2]);
+
+        // Assert
+        Assert.Equal(2, testClass.PropertyC);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Field, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    [Fact]
+    public void InvokerFactory_Class_Private_FieldGetter()
+    {
+        // Arrange
+        var testClass = new TestClass();
+        testClass.SetC(5);
+
+        var privateMember = typeof(TestClass).GetField("_propertyC", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker(typeof(TestClass), privateMember!);
+        var c = invoker.FastInvoke<int>(testClass);
+
+        // Assert
+        Assert.Equal(testClass.PropertyC, c);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Field, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    #endregion
+
+    #region Properties
+
+    [Fact]
+    public void InvokerFactory_Class_Public_PropertySetter()
+    {
+        // Arrange
+        var testClass = new TestClass()
+        {
+            PropertyA = 1
+        };
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyA);
+        invoker.FastInvoke(testClass, [2]);
+
+        // Assert
+        Assert.Equal(2, testClass.PropertyA);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Property, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    [Fact]
+    public void InvokerFactory_Class_Public_PropertyGetter()
+    {
+        // Arrange
+        var testClass = new TestClass()
+        {
+            PropertyA = 1
+        };
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyA);
+        var a = invoker.FastInvoke<int>(testClass);
+
+        // Assert
+        Assert.Equal(testClass.PropertyA, a);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Property, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    #endregion
+
+    #region Methods
+
+    [Fact]
+    public void InvokerFactory_Class_Method_Void()
+    {
+        // Arrange
+        var testClass = new TestClass()
+        {
+            PropertyA = 12
+        };
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.MethodA(0));
+
+        // Act
+        invoker.FastInvoke(testClass, [2]);
+
+        // Assert
+        Assert.Equal(2, testClass.PropertyA);
+        Assert.Single(invoker.ParameterTypes); 
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(void), invoker.ReturnType);
+        Assert.Equal(InvocationType.Method, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    [Fact]
+    public void InvokerFactory_Class_Method_ReturnsOutput()
+    {
+        // Arrange
+        var testClass = new TestClass()
+        {
+            PropertyA = 12
+        };
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.MethodB(0));
+        var result = (int)invoker.FastInvoke(testClass, [2]);
+
+        // Assert
+        Assert.Equal(2, result);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Method, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
+    #endregion
 }

--- a/src/OSK.Expression.Invoker.UnitTests/_Helpers/TestClass.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/_Helpers/TestClass.cs
@@ -1,26 +1,25 @@
-﻿namespace OSK.Expression.Invoker.UnitTests._Helpers
+﻿namespace OSK.Expression.Invoker.UnitTests._Helpers;
+
+public class TestClass
 {
-    public class TestClass
+    public int PropertyA { get; set; }
+    public int PropertyB;
+    private int _propertyC;
+
+    public void SetC(int c)
     {
-        public int PropertyA { get; set; }
-        public int PropertyB;
-        private int _propertyC;
+        _propertyC = c; 
+    }
 
-        public void SetC(int c)
-        {
-            _propertyC = c; 
-        }
+    public int PropertyC => _propertyC;
 
-        public int PropertyC => _propertyC;
+    public void MethodA(int a)
+    {
+        PropertyA = a;
+    }
 
-        public void MethodA(int a)
-        {
-            PropertyA = a;
-        }
-
-        public int MethodB(int c)
-        {
-            return c;
-        }
+    public int MethodB(int c)
+    {
+        return c;
     }
 }

--- a/src/OSK.Expressions.Invoker/Internal/FastInvoker.cs
+++ b/src/OSK.Expressions.Invoker/Internal/FastInvoker.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace OSK.Expressions.Invoker.Internal;
 
-internal sealed class FastInvoker(Func<object, object[], object> func, MemberKey memberKey, InvocationType invocationType,
+internal sealed class FastInvoker(Func<object, object[], object> accessorCallback, Func<object, object>? getterCallback, MemberKey memberKey, InvocationType invocationType,
     Type invokeTargetType) : IInvoker
 {
     #region IInvoker
@@ -18,7 +18,9 @@ internal sealed class FastInvoker(Func<object, object[], object> func, MemberKey
     public Type[] ParameterTypes => memberKey.ParameterTypes ?? [];
 
     public object FastInvoke(object target, params object[] args)
-        => func(target, args);
+        => invocationType is InvocationType.Method || getterCallback is null || args is { Length: >0 }
+            ? accessorCallback(target, args)
+            : getterCallback(target);
 
     #endregion
 }

--- a/src/OSK.Expressions.Invoker/InvokerExtensions.cs
+++ b/src/OSK.Expressions.Invoker/InvokerExtensions.cs
@@ -3,36 +3,38 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace OSK.Expressions.Invoker
+namespace OSK.Expressions.Invoker;
+
+public static class InvokerExtensions
 {
-    public static class InvokerExtensions
+    extension(IInvoker invoker)
     {
-        extension(IInvoker invoker)
-        {
-            /// <summary>
-            /// Effeciently run the invoker on the targeted object without parameters
-            /// </summary>
-            /// <param name="invokeTarget">The object to invoke</param>
-            /// <returns></returns>
-            public object FastInvoke(object invokeTarget)
-                => invoker.FastInvoke(invokeTarget, []);
+        /// <summary>
+        /// Effeciently run the invoker on the targeted object without parameters
+        /// </summary>
+        /// <param name="invokeTarget">The object to invoke</param>
+        /// <returns></returns>
+        public object FastInvoke(object invokeTarget)
+            => invoker.FastInvoke(invokeTarget, []);
 
-            /// <summary>
-            /// Effeciently run the invoker on the targeted object without parameters
-            /// </summary>
-            /// <param name="invokeTarget">The object to invoke</param>
-            /// <returns>A typed result</returns>
-            public T FastInvoke<T>(object invokeTarget)
-                => (T)invoker.FastInvoke(invokeTarget, []);
+        public object FastInvoke(object invokeTarget, params object[] parameters)
+            => invoker.FastInvoke(invokeTarget, parameters);
 
-            /// <summary>
-            /// Effeciently run the invoker on the targeted object
-            /// </summary>
-            /// <param name="invokeTarget">The object to invoke</param>
-            /// <param name="parameters">The parameters to pass to the invocation</param>
-            /// <returns></returns>
-            public T FastInvoke<T>(object invokeTarget, object[] parameters)
-                => (T)invoker.FastInvoke(invokeTarget, parameters);
-        }
+        /// <summary>
+        /// Effeciently run the invoker on the targeted object without parameters
+        /// </summary>
+        /// <param name="invokeTarget">The object to invoke</param>
+        /// <returns>A typed result</returns>
+        public T FastInvoke<T>(object invokeTarget)
+            => (T)invoker.FastInvoke(invokeTarget, []);
+
+        /// <summary>
+        /// Effeciently run the invoker on the targeted object
+        /// </summary>
+        /// <param name="invokeTarget">The object to invoke</param>
+        /// <param name="parameters">The parameters to pass to the invocation</param>
+        /// <returns></returns>
+        public T FastInvoke<T>(object invokeTarget, params object[] parameters)
+            => (T)invoker.FastInvoke(invokeTarget, parameters);
     }
 }

--- a/src/OSK.Expressions.Invoker/InvokerFactory.cs
+++ b/src/OSK.Expressions.Invoker/InvokerFactory.cs
@@ -7,187 +7,212 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace OSK.Expressions.Invoker
+namespace OSK.Expressions.Invoker;
+
+public static class InvokerFactory
 {
-    public static class InvokerFactory
+    #region Variables
+
+    private static readonly ConcurrentDictionary<MemberKey, FastInvoker> MemberInvokerMapLookup = new(MemberKeyComparer.Instance);
+
+    #endregion
+
+    #region Api
+
+    /// <summary>
+    /// Create a <see cref="IInvoker"/> using a strongly typed reference and an expression to retrieve the member data.
+    /// </summary>
+    /// <typeparam name="T">The object target type</typeparam>
+    /// <param name="memberSelector">An expression to retrieve the member</param>
+    /// <returns><see cref="IInvoker"/></returns>
+    public static IInvoker CreateInvoker<T>(Expression<Action<T>> memberSelector)
+        => CreateInvoker(typeof(T), GetMemberInfo(memberSelector));
+
+    /// <summary>
+    /// Create a <see cref="IInvoker"/> using a strongly typed reference and an expression to retrieve the member data.
+    /// </summary>
+    /// <typeparam name="T">The object target type</typeparam>
+    /// <param name="memberSelector">An expression to retrieve the member</param>
+    /// <returns><see cref="IInvoker"/></returns>
+    public static IInvoker CreateInvoker<T>(Expression<Func<T, object>> memberSelector)
+        => CreateInvoker(typeof(T), GetMemberInfo(memberSelector));
+
+    /// <summary>
+    /// Create a <see cref="IInvoker"/> using a strongly typed reference and a member info
+    /// </summary>
+    /// <typeparam name="T">The object target type</typeparam>
+    /// <param name="memberInfo">The member info to create an invoker for</param>
+    /// <returns><see cref="IInvoker"/></returns>
+    public static IInvoker CreateInvoker<T>(MemberInfo memberInfo)
+        => CreateInvoker(typeof(T), memberInfo);
+
+    /// <summary>
+    /// Creates a <see cref="IInvoker"/> using a <see cref="MemberInfo"/>, provided a target object type
+    /// </summary>
+    /// <param name="invocationTargetType">The target object type that contians the member</param>
+    /// <param name="memberInfo">The member info to build the invoker for</param>
+    /// <returns><see cref="IInvoker"/></returns>
+    /// <exception cref="ArgumentNullException">Member Info can not be null</exception>
+    public static IInvoker CreateInvoker(Type invocationTargetType, MemberInfo memberInfo)
     {
-        #region Variables
-
-        private static readonly ConcurrentDictionary<MemberKey, FastInvoker> MemberToWrapperMap
-            = new ConcurrentDictionary<MemberKey, FastInvoker>(MemberKeyComparer.Instance);
-
-        #endregion
-
-        #region Api
-
-        /// <summary>
-        /// Create a <see cref="IInvoker"/> using a strongly typed reference and an expression to retrieve the member data.
-        /// </summary>
-        /// <typeparam name="T">The object target type</typeparam>
-        /// <param name="memberSelector">An expression to retrieve the member</param>
-        /// <returns><see cref="IInvoker"/></returns>
-        public static IInvoker CreateInvoker<T>(Expression<Action<T>> memberSelector)
-            => CreateInvoker(typeof(T), GetMemberInfo(memberSelector));
-
-        /// <summary>
-        /// Create a <see cref="IInvoker"/> using a strongly typed reference and an expression to retrieve the member data.
-        /// </summary>
-        /// <typeparam name="T">The object target type</typeparam>
-        /// <param name="memberSelector">An expression to retrieve the member</param>
-        /// <returns><see cref="IInvoker"/></returns>
-        public static IInvoker CreateInvoker<T>(Expression<Func<T, object>> memberSelector)
-            => CreateInvoker(typeof(T), GetMemberInfo(memberSelector));
-
-        /// <summary>
-        /// Create a <see cref="IInvoker"/> using a strongly typed reference and a member info
-        /// </summary>
-        /// <typeparam name="T">The object target type</typeparam>
-        /// <param name="memberInfo">The member info to create an invoker for</param>
-        /// <returns><see cref="IInvoker"/></returns>
-        public static IInvoker CreateInvoker<T>(MemberInfo memberInfo)
-            => CreateInvoker(typeof(T), memberInfo);
-
-        /// <summary>
-        /// Creates a <see cref="IInvoker"/> using a <see cref="MemberInfo"/>, provided a target object type
-        /// </summary>
-        /// <param name="invocationTargetType">The target object type that contians the member</param>
-        /// <param name="memberInfo">The member info to build the invoker for</param>
-        /// <returns><see cref="IInvoker"/></returns>
-        /// <exception cref="ArgumentNullException">Member Info can not be null</exception>
-        public static IInvoker CreateInvoker(Type invocationTargetType, MemberInfo memberInfo)
+        if (invocationTargetType is null)
         {
-            if (invocationTargetType is null)
-            {
-                throw new ArgumentNullException(nameof(invocationTargetType));
-            }
-            if (memberInfo == null)
-            {
-                throw new ArgumentNullException(nameof(memberInfo));
-            }
+            throw new ArgumentNullException(nameof(invocationTargetType));
+        }
+        if (memberInfo == null)
+        {
+            throw new ArgumentNullException(nameof(memberInfo));
+        }
 
-            if (memberInfo is MethodInfo methodInfo)
+        if (memberInfo is MethodInfo methodInfo)
+        {
+            var methodKey = new MemberKey(invocationTargetType, methodInfo.Name, 
+                methodInfo.GetParameters().Select(p => p.ParameterType).ToArray(), GetReturnType(memberInfo));
+            return MemberInvokerMapLookup.GetOrAdd(methodKey, memberKey =>
             {
-                var methodKey = new MemberKey(invocationTargetType, methodInfo.Name, 
-                    methodInfo.GetParameters().Select(p => p.ParameterType).ToArray(), GetReturnType(memberInfo));
-                return MemberToWrapperMap.GetOrAdd(methodKey, memberKey =>
-                {
-                    var compiledExpression = CreateMethodCompiledExpression(memberKey.InvocationTargetType, methodInfo, false);
-                    return new FastInvoker(compiledExpression, memberKey, InvocationType.Method, invocationTargetType);
-                });
-            }
-
-            var memberKey = new MemberKey(invocationTargetType, memberInfo.Name, [], GetReturnType(memberInfo));
-            return MemberToWrapperMap.GetOrAdd(memberKey, k =>
-            {
-                var (compiledExpression, memberType) = CreateMemberCompiledExpression(invocationTargetType, memberInfo);
-                return new FastInvoker(compiledExpression, k.SetParameterTypes(memberType), 
-                    memberInfo is PropertyInfo _ ? InvocationType.Property : InvocationType.Field,
-                    invocationTargetType);
+                var methodAccessorExpression = CreateMethodCompiledExpression(memberKey.InvocationTargetType, methodInfo);
+                return new FastInvoker(methodAccessorExpression, null, memberKey, InvocationType.Method, invocationTargetType);
             });
         }
 
-        #endregion
-
-        #region Helpers
-
-        private static Type GetReturnType(MemberInfo memberInfo)
-            => memberInfo switch
-            {
-                PropertyInfo p => p.PropertyType,
-                FieldInfo f => f.FieldType,
-                MethodInfo m => m.ReturnType,
-                _ => throw new ArgumentException($"Member must be a Property, Field, or Method but was of type {memberInfo.GetType().FullName}")
-            };
-
-        private static MemberInfo GetMemberInfo(LambdaExpression expression)
+        var memberKey = new MemberKey(invocationTargetType, memberInfo.Name, [], GetReturnType(memberInfo));
+        return MemberInvokerMapLookup.GetOrAdd(memberKey, k =>
         {
-            Expression body = expression.Body;
+            var accessorExpressions = CreateAccessorExpressions(invocationTargetType, memberInfo);
+            return new FastInvoker(accessorExpressions.AccessorCallback, accessorExpressions.GetterCallback, k.SetParameterTypes(accessorExpressions.MemberType), 
+                memberInfo is PropertyInfo _ ? InvocationType.Property : InvocationType.Field,
+                invocationTargetType);
+        });
+    }
 
-            // If the property returns a value type (int, bool), 
-            // the body will be wrapped in a 'Convert' (UnaryExpression)
-            if (body is UnaryExpression unary)
-            {
-                body = unary.Operand;
-            }
+    #endregion
 
-            if (body is MethodCallExpression methodCallExpression)
-            {
-                return methodCallExpression.Method;
-            }
-            if (body is MemberExpression memberExpression)
-            {
-                return memberExpression.Member;
-            }
+    #region Helpers
 
-            throw new ArgumentException("Expression is not a supported member access (Property, Field, or Method).");
+    private static Type GetReturnType(MemberInfo memberInfo)
+        => memberInfo switch
+        {
+            PropertyInfo p => p.PropertyType,
+            FieldInfo f => f.FieldType,
+            MethodInfo m => m.ReturnType,
+            _ => throw new ArgumentException($"Member must be a Property, Field, or Method but was of type {memberInfo.GetType().FullName}")
+        };
+
+    private static MemberInfo GetMemberInfo(LambdaExpression expression)
+    {
+        Expression body = expression.Body;
+
+        // If the property returns a value type (int, bool), 
+        // the body will be wrapped in a 'Convert' (UnaryExpression)
+        if (body is UnaryExpression unary)
+        {
+            body = unary.Operand;
         }
 
-        private static Func<object, object[], object> CreateMethodCompiledExpression(Type type, MethodInfo method, bool isDelegate)
+        if (body is MethodCallExpression methodCallExpression)
         {
-            CreateParamsExpressions(method, out ParameterExpression argsExp, out Expression[] paramsExps);
-
-            var targetExp = Expression.Parameter(typeof(object), "target");
-            var castTargetExp = Expression.Convert(targetExp, type);
-            var invokeExp = isDelegate
-                ? (Expression)Expression.Invoke(castTargetExp, paramsExps)
-                : Expression.Call(castTargetExp, method, paramsExps);
-
-            LambdaExpression lambdaExp;
-
-            if (method.ReturnType != typeof(void))
-            {
-                var resultExp = Expression.Convert(invokeExp, typeof(object));
-                lambdaExp = Expression.Lambda(resultExp, targetExp, argsExp);
-            }
-            else
-            {
-                var constExp = Expression.Constant(null, typeof(object));
-                var blockExp = Expression.Block(invokeExp, constExp);
-                lambdaExp = Expression.Lambda(blockExp, targetExp, argsExp);
-            }
-
-            var lambda = lambdaExp.Compile();
-            return (Func<object, object[], object>)lambda;
+            return methodCallExpression.Method;
+        }
+        if (body is MemberExpression memberExpression)
+        {
+            return memberExpression.Member;
         }
 
-        private static Tuple<Func<object, object[], object>, Type> CreateMemberCompiledExpression(Type type, MemberInfo memberInfo)
+        throw new ArgumentException("Expression is not a supported member access (Property, Field, or Method).");
+    }
+
+    private static Func<object, object[], object> CreateMethodCompiledExpression(Type type, MethodInfo method)
+    {
+        CreateParamsExpressions(method, out ParameterExpression argsExp, out Expression[] paramsExps);
+
+        var targetExp = Expression.Parameter(typeof(object), "target");
+        var castTargetExp = Expression.Convert(targetExp, type);
+
+        var invokeExp = Expression.Call(castTargetExp, method, paramsExps);
+        LambdaExpression lambdaExp;
+
+        if (method.ReturnType != typeof(void))
         {
-            var targetExp = Expression.Parameter(typeof(object), "target");
-            var argsExp = Expression.Parameter(typeof(object[]), "args");
-            var valueObjExp = Expression.ArrayIndex(argsExp, Expression.Constant(0));
+            var resultExp = Expression.Convert(invokeExp, typeof(object));
+            lambdaExp = Expression.Lambda(resultExp, targetExp, argsExp);
+        }
+        else
+        {
+            var constExp = Expression.Constant(null, typeof(object));
+            var blockExp = Expression.Block(invokeExp, constExp);
+            lambdaExp = Expression.Lambda(blockExp, targetExp, argsExp);
+        }
 
-            var castArgExp = Expression.Convert(targetExp, type);
+        var lambda = lambdaExp.Compile();
+        return (Func<object, object[], object>)lambda;
+    }
 
-            var memberExp = memberInfo is PropertyInfo
-                ? Expression.Property(castArgExp, type.GetRuntimeProperty(memberInfo.Name))
-                : Expression.Field(castArgExp, type.GetField(memberInfo.Name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
-            var castValueExp = Expression.Convert(valueObjExp, memberExp.Type);
+    private static (Func<object, object[], object> AccessorCallback, Func<object, object>? GetterCallback, Type MemberType) CreateAccessorExpressions(Type type, MemberInfo memberInfo)
+    {
+        var targetExp = Expression.Parameter(typeof(object), "target");
+        var argsExp = Expression.Parameter(typeof(object[]), "args");
+        var castArgExp = Expression.Convert(targetExp, type);
 
-            var assignExp = Expression.Assign(memberExp, castValueExp);
-            Expression finalBody = memberExp.Type.IsValueType
+        var expressionData = memberInfo switch
+        {
+            PropertyInfo propertyInfo => new
+            {
+                propertyInfo.Name,
+                MemberType = propertyInfo.PropertyType,
+                IsProperty = true,
+                HasGetter = propertyInfo.CanRead,
+                IsInitOnly = propertyInfo.SetMethod?.ReturnParameter.GetRequiredCustomModifiers().Contains(typeof(System.Runtime.CompilerServices.IsExternalInit)) ?? false
+            },
+            FieldInfo fieldInfo => new
+            {
+                fieldInfo.Name,
+                MemberType = fieldInfo.FieldType,
+                IsProperty = false,
+                HasGetter = true,
+                fieldInfo.IsInitOnly
+            },
+            _ => throw new InvalidOperationException($"Unable to create accessor expressions for member info of type {memberInfo.GetType().FullName}")
+        };
+
+        var memberExp = expressionData.IsProperty
+            ? Expression.Property(castArgExp, type.GetRuntimeProperty(expressionData.Name))
+            : Expression.Field(castArgExp, type.GetField(expressionData.Name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+
+        var valueObjExp = Expression.ArrayIndex(argsExp, Expression.Constant(0));
+        var castValueExp = Expression.Convert(valueObjExp, memberExp.Type);
+
+        Func<object, object>? getterCallback = null;
+        if (expressionData.HasGetter)
+        {
+            var getterBody = Expression.Convert(memberExp, typeof(object));
+            var getterExpression = Expression.Lambda<Func<object, object>>(getterBody, targetExp);
+            getterCallback = getterExpression.Compile();
+        }
+
+        var assignExp = Expression.Assign(memberExp, castValueExp);
+        Expression setterBody = memberExp.Type.IsValueType
             ? Expression.Convert(assignExp, typeof(object))
             : assignExp;
-            var lambdaExp = Expression.Lambda(finalBody, targetExp, argsExp);
+        var setterExpression = Expression.Lambda(setterBody, targetExp, argsExp);
 
-            var lambda = lambdaExp.Compile();
-            return new Tuple<Func<object, object[], object>, Type>((Func<object, object[], object>)lambda, memberExp.Type);
-        }
-
-        private static void CreateParamsExpressions(MethodBase method, out ParameterExpression argsExp, out Expression[] paramsExps)
-        {
-            var parameters = method.GetParameters().Select(parameter => parameter.ParameterType).ToList();
-
-            argsExp = Expression.Parameter(typeof(object[]), "args");
-            paramsExps = new Expression[parameters.Count];
-
-            for (var i = 0; i < parameters.Count; i++)
-            {
-                var constExp = Expression.Constant(i, typeof(int));
-                var argExp = Expression.ArrayIndex(argsExp, constExp);
-                paramsExps[i] = Expression.Convert(argExp, parameters[i]);
-            }
-        }
-
-        #endregion
+        var accessorCallback = (Func<object, object[], object>)setterExpression.Compile();
+        return new(accessorCallback, getterCallback, memberExp.Type);
     }
+
+    private static void CreateParamsExpressions(MethodBase method, out ParameterExpression argsExp, out Expression[] paramsExps)
+    {
+        var parameters = method.GetParameters().Select(parameter => parameter.ParameterType).ToList();
+
+        argsExp = Expression.Parameter(typeof(object[]), "args");
+        paramsExps = new Expression[parameters.Count];
+
+        for (var i = 0; i < parameters.Count; i++)
+        {
+            var constExp = Expression.Constant(i, typeof(int));
+            var argExp = Expression.ArrayIndex(argsExp, constExp);
+            paramsExps[i] = Expression.Convert(argExp, parameters[i]);
+        }
+    }
+
+    #endregion
 }

--- a/src/OSK.Expressions.Invoker/Models/InvocationType.cs
+++ b/src/OSK.Expressions.Invoker/Models/InvocationType.cs
@@ -1,9 +1,10 @@
-﻿namespace OSK.Expressions.Invoker.Models
+﻿using System;
+
+namespace OSK.Expressions.Invoker.Models;
+
+public enum InvocationType
 {
-    public enum InvocationType
-    {
-        Method,
-        Property,
-        Field
-    }
+    Method,
+    Property,
+    Field
 }

--- a/src/OSK.Expressions.Invoker/OSK.Expressions.Invoker.csproj
+++ b/src/OSK.Expressions.Invoker/OSK.Expressions.Invoker.csproj
@@ -25,6 +25,10 @@
 
 	<ItemGroup>
 	  <PackageReference Include="OSK.Hexagonal.MetaData" Version="1.0.0" />
+	  <PackageReference Include="PolySharp" Version="1.15.0">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Expressions.Invoker/Ports/IInvoker.cs
+++ b/src/OSK.Expressions.Invoker/Ports/IInvoker.cs
@@ -2,37 +2,36 @@
 using OSK.Hexagonal.MetaData;
 using System;
 
-namespace OSK.Expressions.Invoker.Ports
+namespace OSK.Expressions.Invoker.Ports;
+
+[HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
+public interface IInvoker
 {
-    [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
-    public interface IInvoker
-    {
-        /// <summary>
-        /// The type of invocation this invoker is configured to support
-        /// </summary>
-        InvocationType InvocationType { get; }
+    /// <summary>
+    /// The type of invocation this invoker is configured to support
+    /// </summary>
+    InvocationType InvocationType { get; }
 
-        /// <summary>
-        /// The type of object that should be passed to the invoker
-        /// </summary>
-        Type InvokeTargetType { get; }
+    /// <summary>
+    /// The type of object that should be passed to the invoker
+    /// </summary>
+    Type InvokeTargetType { get; }
 
-        /// <summary>
-        /// The expected parameter types to be provided to the invoker to function
-        /// </summary>
-        Type[] ParameterTypes { get; }
+    /// <summary>
+    /// The expected parameter types to be provided to the invoker to function
+    /// </summary>
+    Type[] ParameterTypes { get; }
 
-        /// <summary>
-        /// The return type of the member info that was used to create this invoker
-        /// </summary>
-        Type ReturnType { get; }
+    /// <summary>
+    /// The return type of the member info that was used to create this invoker
+    /// </summary>
+    Type ReturnType { get; }
 
-        /// <summary>
-        /// Effeciently run the invoker on the targeted object
-        /// </summary>
-        /// <param name="invokeTarget">The object to invoke</param>
-        /// <param name="parameters">The parameters to pass to the invocation</param>
-        /// <returns></returns>
-        object FastInvoke(object invokeTarget, object[] parameters);
-    }
+    /// <summary>
+    /// Effeciently run the invoker on the targeted object
+    /// </summary>
+    /// <param name="invokeTarget">The object to invoke</param>
+    /// <param name="parameters">The parameters to pass to the invocation</param>
+    /// <returns></returns>
+    object FastInvoke(object invokeTarget, object[] parameters);
 }


### PR DESCRIPTION
Motivation
----
Getter methods do not work

Modifications
----
* Updated FastInvoker to account for getter
* Updated InvokerFactory to handle creating getter callbacks
* Added unit tests for use case
* Updated docs for quick usage steps

Result
----
Invoker now supports getter fields/properties

Fixes #5