### PR TITLE
Support GETTer only properties (OSK-7)

### DIFF
--- a/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
@@ -147,6 +147,25 @@ public class InvokerFactoryTests
         Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
     }
 
+    [Fact]
+    public void InvokerFactory_Class_Public_PropertyGetterOnly()
+    {
+        // Arrange
+        var testClass = new TestClass();
+
+        // Act
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyDGetter);
+        var d = invoker.FastInvoke<int>(testClass);
+
+        // Assert
+        Assert.Equal(testClass.PropertyDGetter, d);
+        Assert.Single(invoker.ParameterTypes);
+        Assert.Equal(typeof(int), invoker.ParameterTypes[0]);
+        Assert.Equal(typeof(int), invoker.ReturnType);
+        Assert.Equal(InvocationType.Property, invoker.InvocationType);
+        Assert.Equal(typeof(TestClass), invoker.InvokeTargetType);
+    }
+
     #endregion
 
     #region Methods

--- a/src/OSK.Expression.Invoker.UnitTests/_Helpers/TestClass.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/_Helpers/TestClass.cs
@@ -6,6 +6,8 @@ public class TestClass
     public int PropertyB;
     private int _propertyC;
 
+    public int PropertyDGetter { get; }
+
     public void SetC(int c)
     {
         _propertyC = c; 

--- a/src/OSK.Expressions.Invoker/Internal/FastInvoker.cs
+++ b/src/OSK.Expressions.Invoker/Internal/FastInvoker.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace OSK.Expressions.Invoker.Internal;
 
-internal sealed class FastInvoker(Func<object, object[], object> accessorCallback, Func<object, object>? getterCallback, MemberKey memberKey, InvocationType invocationType,
+internal sealed class FastInvoker(Func<object, object[], object>? accessorCallback, Func<object, object>? getterCallback, MemberKey memberKey, InvocationType invocationType,
     Type invokeTargetType) : IInvoker
 {
     #region IInvoker
@@ -18,9 +18,24 @@ internal sealed class FastInvoker(Func<object, object[], object> accessorCallbac
     public Type[] ParameterTypes => memberKey.ParameterTypes ?? [];
 
     public object FastInvoke(object target, params object[] args)
-        => invocationType is InvocationType.Method || getterCallback is null || args is { Length: >0 }
-            ? accessorCallback(target, args)
-            : getterCallback(target);
+    {
+        if (invocationType is InvocationType.Method || args is { Length: > 0 })
+        {
+            if (accessorCallback is null)
+            {
+                throw new InvalidOperationException($"No accessor/setter callback exists for the invocation of target type {target.GetType().FullName}.");
+            }
+
+            return accessorCallback(target, args);
+        }
+
+        if (getterCallback is null)
+        {
+            throw new InvalidOperationException("No getter callback exists for getter invocation.");
+        }
+
+        return getterCallback(target);
+    }
 
     #endregion
 }

--- a/src/OSK.Expressions.Invoker/InvokerFactory.cs
+++ b/src/OSK.Expressions.Invoker/InvokerFactory.cs
@@ -66,8 +66,8 @@ public static class InvokerFactory
 
         if (memberInfo is MethodInfo methodInfo)
         {
-            var methodKey = new MemberKey(invocationTargetType, methodInfo.Name, 
-                methodInfo.GetParameters().Select(p => p.ParameterType).ToArray(), GetReturnType(memberInfo));
+            var methodKey = new MemberKey(invocationTargetType, methodInfo.Name,
+                [.. methodInfo.GetParameters().Select(p => p.ParameterType)], GetReturnType(memberInfo));
             return MemberInvokerMapLookup.GetOrAdd(methodKey, memberKey =>
             {
                 var methodAccessorExpression = CreateMethodCompiledExpression(memberKey.InvocationTargetType, methodInfo);
@@ -79,7 +79,7 @@ public static class InvokerFactory
         return MemberInvokerMapLookup.GetOrAdd(memberKey, k =>
         {
             var accessorExpressions = CreateAccessorExpressions(invocationTargetType, memberInfo);
-            return new FastInvoker(accessorExpressions.AccessorCallback, accessorExpressions.GetterCallback, k.SetParameterTypes(accessorExpressions.MemberType), 
+            return new FastInvoker(accessorExpressions.SetterCallback, accessorExpressions.GetterCallback, k.SetParameterTypes(accessorExpressions.MemberType), 
                 memberInfo is PropertyInfo _ ? InvocationType.Property : InvocationType.Field,
                 invocationTargetType);
         });
@@ -147,7 +147,7 @@ public static class InvokerFactory
         return (Func<object, object[], object>)lambda;
     }
 
-    private static (Func<object, object[], object> AccessorCallback, Func<object, object>? GetterCallback, Type MemberType) CreateAccessorExpressions(Type type, MemberInfo memberInfo)
+    private static (Func<object, object> GetterCallback, Func<object, object[], object>? SetterCallback, Type MemberType) CreateAccessorExpressions(Type type, MemberInfo memberInfo)
     {
         var targetExp = Expression.Parameter(typeof(object), "target");
         var argsExp = Expression.Parameter(typeof(object[]), "args");
@@ -160,7 +160,7 @@ public static class InvokerFactory
                 propertyInfo.Name,
                 MemberType = propertyInfo.PropertyType,
                 IsProperty = true,
-                HasGetter = propertyInfo.CanRead,
+                HasSetter = propertyInfo.CanWrite,
                 IsInitOnly = propertyInfo.SetMethod?.ReturnParameter.GetRequiredCustomModifiers().Contains(typeof(System.Runtime.CompilerServices.IsExternalInit)) ?? false
             },
             FieldInfo fieldInfo => new
@@ -168,7 +168,7 @@ public static class InvokerFactory
                 fieldInfo.Name,
                 MemberType = fieldInfo.FieldType,
                 IsProperty = false,
-                HasGetter = true,
+                HasSetter = true,
                 fieldInfo.IsInitOnly
             },
             _ => throw new InvalidOperationException($"Unable to create accessor expressions for member info of type {memberInfo.GetType().FullName}")
@@ -181,22 +181,23 @@ public static class InvokerFactory
         var valueObjExp = Expression.ArrayIndex(argsExp, Expression.Constant(0));
         var castValueExp = Expression.Convert(valueObjExp, memberExp.Type);
 
-        Func<object, object>? getterCallback = null;
-        if (expressionData.HasGetter)
+        var getterBody = Expression.Convert(memberExp, typeof(object));
+        var getterExpression = Expression.Lambda<Func<object, object>>(getterBody, targetExp);
+        var getterCallback = getterExpression.Compile();
+
+        Func<object, object[], object>? setterCallback = null;
+        if (expressionData.HasSetter)
         {
-            var getterBody = Expression.Convert(memberExp, typeof(object));
-            var getterExpression = Expression.Lambda<Func<object, object>>(getterBody, targetExp);
-            getterCallback = getterExpression.Compile();
+            var assignExp = Expression.Assign(memberExp, castValueExp);
+            Expression setterBody = memberExp.Type.IsValueType
+                ? Expression.Convert(assignExp, typeof(object))
+                : assignExp;
+            var setterExpression = Expression.Lambda(setterBody, targetExp, argsExp);
+
+            setterCallback = (Func<object, object[], object>)setterExpression.Compile();
         }
 
-        var assignExp = Expression.Assign(memberExp, castValueExp);
-        Expression setterBody = memberExp.Type.IsValueType
-            ? Expression.Convert(assignExp, typeof(object))
-            : assignExp;
-        var setterExpression = Expression.Lambda(setterBody, targetExp, argsExp);
-
-        var accessorCallback = (Func<object, object[], object>)setterExpression.Compile();
-        return new(accessorCallback, getterCallback, memberExp.Type);
+        return new(getterCallback, setterCallback, memberExp.Type);
     }
 
     private static void CreateParamsExpressions(MethodBase method, out ParameterExpression argsExp, out Expression[] paramsExps)


### PR DESCRIPTION
Motivation
----
The current implementation requires both GETter/SETters to be used, but there can be GETters only

Modifications
----
* Adjusted InvokerFactory to account for the GETter only case
* Adjusted FastInvoker to handle the change
* Added unit tests for use case

Result
----
GETter only is allowed

Fixes #7