### PR TITLE
Fix bug with internal properties (OSK-9)

### DIFF
--- a/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
@@ -33,6 +33,29 @@ public class InvokerFactoryTests
     }
 
     [Fact]
+    public void InvokerFactory_Internal_Property_GetterSetter()
+    {
+        // Arrange
+        var testClass = new TestClass()
+        {
+            PropertyD = 5
+        };
+
+        // Act - getter
+        var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyD);
+        var val = invoker.FastInvoke<int>(testClass);
+
+        // Assert getter
+        Assert.Equal(5, val);
+
+        // Act - setter
+        invoker.FastInvoke(testClass, [10]);
+
+        // Assert setter
+        Assert.Equal(10, testClass.PropertyD);
+    }
+
+    [Fact]
     public void InvokerFactory_Class_Public_FieldGetter()
     {
         // Arrange

--- a/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/InvokerFactoryTests.cs
@@ -41,17 +41,14 @@ public class InvokerFactoryTests
             PropertyD = 5
         };
 
-        // Act - getter
         var invoker = InvokerFactory.CreateInvoker<TestClass>(t => t.PropertyD);
-        var val = invoker.FastInvoke<int>(testClass);
 
-        // Assert getter
-        Assert.Equal(5, val);
-
-        // Act - setter
+        // Act
+        var originalValue = invoker.FastInvoke<int>(testClass);
         invoker.FastInvoke(testClass, [10]);
 
-        // Assert setter
+        // Assert
+        Assert.Equal(5, originalValue);
         Assert.Equal(10, testClass.PropertyD);
     }
 

--- a/src/OSK.Expression.Invoker.UnitTests/_Helpers/TestClass.cs
+++ b/src/OSK.Expression.Invoker.UnitTests/_Helpers/TestClass.cs
@@ -6,6 +6,8 @@ public class TestClass
     public int PropertyB;
     private int _propertyC;
 
+    internal int PropertyD { get; set; }
+
     public int PropertyDGetter { get; }
 
     public void SetC(int c)

--- a/src/OSK.Expressions.Invoker/InvokerFactory.cs
+++ b/src/OSK.Expressions.Invoker/InvokerFactory.cs
@@ -174,9 +174,10 @@ public static class InvokerFactory
             _ => throw new InvalidOperationException($"Unable to create accessor expressions for member info of type {memberInfo.GetType().FullName}")
         };
 
+        var bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
         var memberExp = expressionData.IsProperty
-            ? Expression.Property(castArgExp, type.GetRuntimeProperty(expressionData.Name))
-            : Expression.Field(castArgExp, type.GetField(expressionData.Name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+            ? Expression.Property(castArgExp, type.GetProperty(expressionData.Name, bindingFlags))
+            : Expression.Field(castArgExp, type.GetField(expressionData.Name, bindingFlags));
 
         var valueObjExp = Expression.ArrayIndex(argsExp, Expression.Constant(0));
         var castValueExp = Expression.Convert(valueObjExp, memberExp.Type);


### PR DESCRIPTION
Motivation
----
The current implementation for the invoker factory is not accurately getting internal properties

Modifications
----
* Update the factory to better handle internal properties

Result
----
Internal properties should be more widely supported

Fixes #9